### PR TITLE
Reverting gocd agent and server versions to 16.12.0 The plugin throws…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   agent:
-    image: gocd/gocd-agent
+    image: gocd/gocd-agent:16.12.0
     depends_on:
       - server
     environment:
@@ -12,7 +12,7 @@ services:
       - ~/.ssh:/var/go/.ssh
 
   server:
-    image: gocd/gocd-server
+    image: gocd/gocd-server:16.12.0
     volumes:
       - ./build/libs/go-cd-git-path-material-plugin-1.3-SNAPSHOT.jar:/plugins/go-cd-git-path-material-plugin-1.3-SNAPSHOT.jar
       - ./extras/yaml-config-plugin-0.1.0.jar:/plugins/yaml-config-plugin-0.1.0.jar


### PR DESCRIPTION
… error in version17