### PR TITLE
fix: remove flyweight/working dirs during failure when created by plugin during initial server-side material check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ tasks.withType(JavaCompile).configureEach {
 
 gocdPlugin {
     id = 'git-path'
-    pluginVersion = '3.0.0'
+    pluginVersion = '3.0.1'
     goCdVersion = '22.1.0'
     name = 'Git Path Material Plugin'
     description = 'Plugin that polls a Git repository and triggers pipelines based on sub-directory path matches'

--- a/src/main/java/com/thoughtworks/go/scm/plugin/git/GitHelper.java
+++ b/src/main/java/com/thoughtworks/go/scm/plugin/git/GitHelper.java
@@ -441,17 +441,52 @@ public class GitHelper {
         return Console.runOrBomb(gitCmd, workingDir, stdOut, stdErr, gitConfig == null ? List.of() : gitConfig.redactables());
     }
 
-    public void cloneOrFetch() {
-        cloneOrFetch(null);
+    /**
+     * @return {@code true} if this invocation freshly cloned the repository (i.e. it was responsible for creating the
+     * working/flyweight directory), {@code false} if an existing clone was reused and only fetched.
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean cloneOrFetch() {
+        return cloneOrFetch((String) null);
     }
 
-    public void cloneOrFetch(String refSpec) {
-        if (!isGitRepository() || !isSameRepository()) {
-            setupWorkingDir();
-            cloneRepository();
-        }
+    /**
+     * @return {@code true} if this invocation freshly cloned the repository (i.e. it was responsible for creating the
+     * working/flyweight directory), {@code false} if an existing clone was reused and only fetched.
+     */
+    public boolean cloneOrFetch(String refSpec) {
+        return cloneOrFetch(refSpec, CloneFailureBehavior.RETAIN_WORKING_DIR);
+    }
 
-        fetchAndResetToHead(refSpec);
+    /**
+     * @return {@code true} if this invocation freshly cloned the repository (i.e. it was responsible for creating the
+     * working/flyweight directory), {@code false} if an existing clone was reused and only fetched.
+     */
+    public boolean cloneOrFetch(CloneFailureBehavior onFailure) {
+        return cloneOrFetch(null, onFailure);
+    }
+
+    /**
+     * @return {@code true} if this invocation freshly cloned the repository (i.e. it was responsible for creating the
+     * working/flyweight directory), {@code false} if an existing clone was reused and only fetched.
+     */
+    public boolean cloneOrFetch(String refSpec, CloneFailureBehavior onFailure) {
+        boolean freshClone = false;
+        try {
+            if (!isGitRepository() || !isSameRepository()) {
+                setupWorkingDir();
+                freshClone = true;
+                cloneRepository();
+            }
+
+            fetchAndResetToHead(refSpec);
+            return freshClone;
+        } catch (RuntimeException e) {
+            if (freshClone && onFailure == CloneFailureBehavior.REMOVE_IF_CREATED) {
+                FileUtils.deleteQuietly(workingDir);
+            }
+            throw e;
+        }
     }
 
     private boolean isGitRepository() {
@@ -518,5 +553,18 @@ public class GitHelper {
 
         stdOut.consumeLine("[GIT] Cleaning unversioned files and sub-modules");
         printSubmoduleStatus();
+    }
+
+    public enum CloneFailureBehavior {
+        /**
+         * Leave the working directory as-is on failure. Appropriate for materials already known to GoCD, whose
+         * flyweight directory is stable and must not be disturbed by a transient failure.
+         */
+        RETAIN_WORKING_DIR,
+        /**
+         * If <em>this</em> invocation created the working directory and the clone/fetch then fails, delete it before
+         * rethrowing, so a first-usage poll does not leave an orphaned, partially-cloned flyweight directory behind.
+         */
+        REMOVE_IF_CREATED
     }
 }

--- a/src/main/java/com/thoughtworks/go/scm/plugin/model/requestHandlers/GetLatestRevisionRequestHandler.java
+++ b/src/main/java/com/thoughtworks/go/scm/plugin/model/requestHandlers/GetLatestRevisionRequestHandler.java
@@ -9,6 +9,7 @@ import com.thoughtworks.go.scm.plugin.git.HelperFactory;
 import com.thoughtworks.go.scm.plugin.git.Revision;
 import com.thoughtworks.go.scm.plugin.util.JsonUtils;
 import com.thoughtworks.go.scm.plugin.util.Validator;
+import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.util.HashMap;
@@ -35,17 +36,19 @@ public class GetLatestRevisionRequestHandler implements RequestHandler {
 
         try {
             GitHelper git = HelperFactory.git(gitConfig, flyweightFolder);
-            git.cloneOrFetch();
+            boolean freshClone = git.cloneOrFetch(GitHelper.CloneFailureBehavior.REMOVE_IF_CREATED);
             final List<String> paths = JsonUtils.getPaths(apiRequest);
             final Revision revision = git.getLatestRevision(paths);
 
             LOGGER.debug(String.format("Fetching latestRevision for paths %s", paths));
 
-            if (revision == null) {
-                return JsonUtils.renderSuccessApiResponse(null);
-            } else {
-                return JsonUtils.renderSuccessApiResponse(Map.of("revision", RevisionUtil.toMap(revision)));
+            if (freshClone && revision == null) {
+                // A brand new material with a path spec that matches no revision would otherwise leave an orphaned
+                // flyweight dir behind forever, because the server will allocate a new one.
+                FileUtils.deleteQuietly(flyweightFolder);
             }
+
+            return JsonUtils.renderSuccessApiResponse(revision == null ? Map.of() : Map.of("revision", RevisionUtil.toMap(revision)));
         } catch (Throwable t) {
             return JsonUtils.renderErrorApiResponse(apiRequest, t, gitConfig.redactables());
         }

--- a/src/test/java/com/thoughtworks/go/scm/plugin/git/GitHelperTest.java
+++ b/src/test/java/com/thoughtworks/go/scm/plugin/git/GitHelperTest.java
@@ -19,6 +19,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static uk.org.webcompere.systemstubs.SystemStubs.restoreSystemProperties;
@@ -103,6 +104,28 @@ public class GitHelperTest {
 
         Revision revision = git.getDetailsForRevision("012e893acea10b140688d11beaa728e8c60bd9f6");
         verifyRevision(revision, "012e893acea10b140688d11beaa728e8c60bd9f6", "1", 1422184635000L, List.of(Pair.of("a.txt", "added")));
+    }
+
+    @Test
+    public void shouldRemoveFreshlyCreatedWorkingDirWhenCloneFailsAndRemovalRequested() {
+        GitConfig gitConfig = new GitConfig(new File(System.getProperty("java.io.tmpdir"), "non-existing-repository").getAbsolutePath());
+        GitHelper git = getHelper(gitConfig, testRepository);
+
+        assertThatThrownBy(() -> git.cloneOrFetch(GitHelper.CloneFailureBehavior.REMOVE_IF_CREATED))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(testRepository).doesNotExist();
+    }
+
+    @Test
+    public void shouldRetainFreshlyCreatedWorkingDirWhenCloneFailsButRemovalNotRequested() {
+        GitConfig gitConfig = new GitConfig(new File(System.getProperty("java.io.tmpdir"), "non-existing-repository").getAbsolutePath());
+        GitHelper git = getHelper(gitConfig, testRepository);
+
+        assertThatThrownBy(() -> git.cloneOrFetch(GitHelper.CloneFailureBehavior.RETAIN_WORKING_DIR))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(testRepository).exists();
     }
 
     @Test

--- a/src/test/java/com/thoughtworks/go/scm/plugin/model/requestHandlers/GetLatestRevisionRequestHandlerTest.java
+++ b/src/test/java/com/thoughtworks/go/scm/plugin/model/requestHandlers/GetLatestRevisionRequestHandlerTest.java
@@ -4,11 +4,13 @@ import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.thoughtworks.go.scm.plugin.git.GitConfig;
 import com.thoughtworks.go.scm.plugin.git.GitHelper;
+import com.thoughtworks.go.scm.plugin.git.GitHelper.CloneFailureBehavior;
 import com.thoughtworks.go.scm.plugin.git.HelperFactory;
 import com.thoughtworks.go.scm.plugin.git.Revision;
 import com.thoughtworks.go.scm.plugin.util.JsonUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -77,7 +79,7 @@ public class GetLatestRevisionRequestHandlerTest {
 
             checkoutRequestHandler.handle(pluginApiRequestMock);
 
-            verify(gitHelperMock).cloneOrFetch();
+            verify(gitHelperMock).cloneOrFetch(CloneFailureBehavior.REMOVE_IF_CREATED);
             verify(gitHelperMock).getLatestRevision(paths);
 
             Map<String, Object> responseMap = responseArgumentCaptor.getValue();
@@ -99,7 +101,7 @@ public class GetLatestRevisionRequestHandlerTest {
 
             when(JsonUtils.renderErrorApiResponse(eq(pluginApiRequestMock), errorCaptor.capture(), any())).thenReturn(mock(GoPluginApiResponse.class));
             when(gitConfigMock.getUrl()).thenReturn("https://github.com/TWChennai/gocd-git-path-material-plugin.git");
-            doThrow(runtimeException).when(gitHelperMock).cloneOrFetch();
+            doThrow(runtimeException).when(gitHelperMock).cloneOrFetch(CloneFailureBehavior.REMOVE_IF_CREATED);
 
             checkoutRequestHandler.handle(pluginApiRequestMock);
 
@@ -108,8 +110,53 @@ public class GetLatestRevisionRequestHandlerTest {
     }
 
 
+    @Test
+    public void shouldRemoveFlyweightDirWhenNoRevisionMatchesPathSpecAndThisInvocationCreatedIt(@TempDir File tempDir) {
+        try (MockedStatic<JsonUtils> mockedUtils = mockStatic(JsonUtils.class);
+             MockedStatic<HelperFactory> mockedFactory = mockStatic(HelperFactory.class)) {
+
+            File flyweightFolder = new File(tempDir, "flyweight");
+            setupMockedRequestAndGitConfig(mockedUtils, mockedFactory, flyweightFolder.getPath());
+            assertThat(flyweightFolder.mkdirs()).isTrue();
+
+            when(JsonUtils.renderSuccessApiResponse(null)).thenReturn(mock(GoPluginApiResponse.class));
+            when(JsonUtils.getPaths(pluginApiRequestMock)).thenReturn(List.of("path1"));
+            when(gitConfigMock.getUrl()).thenReturn("https://github.com/TWChennai/gocd-git-path-material-plugin.git");
+            when(gitHelperMock.cloneOrFetch(CloneFailureBehavior.REMOVE_IF_CREATED)).thenReturn(true);
+            when(gitHelperMock.getLatestRevision(any())).thenReturn(null);
+
+            new GetLatestRevisionRequestHandler().handle(pluginApiRequestMock);
+
+            assertThat(flyweightFolder).doesNotExist();
+        }
+    }
+
+    @Test
+    public void shouldNotRemoveFlyweightDirWhenNoRevisionMatchesButThisInvocationReusedExistingClone(@TempDir File tempDir) {
+        try (MockedStatic<JsonUtils> mockedUtils = mockStatic(JsonUtils.class);
+             MockedStatic<HelperFactory> mockedFactory = mockStatic(HelperFactory.class)) {
+
+            File flyweightFolder = new File(tempDir, "flyweight");
+            setupMockedRequestAndGitConfig(mockedUtils, mockedFactory, flyweightFolder.getPath());
+            assertThat(flyweightFolder.mkdirs()).isTrue();
+
+            when(JsonUtils.renderSuccessApiResponse(null)).thenReturn(mock(GoPluginApiResponse.class));
+            when(JsonUtils.getPaths(pluginApiRequestMock)).thenReturn(List.of("path1"));
+            when(gitConfigMock.getUrl()).thenReturn("https://github.com/TWChennai/gocd-git-path-material-plugin.git");
+            when(gitHelperMock.cloneOrFetch(CloneFailureBehavior.REMOVE_IF_CREATED)).thenReturn(false);
+            when(gitHelperMock.getLatestRevision(any())).thenReturn(null);
+
+            new GetLatestRevisionRequestHandler().handle(pluginApiRequestMock);
+
+            assertThat(flyweightFolder).exists();
+        }
+    }
+
     private void setupMockedRequestAndGitConfig(MockedStatic<JsonUtils> mockedUtils, MockedStatic<HelperFactory> mockedFactory) {
-        final String flyWeightFolder = "flyweightFolder";
+        setupMockedRequestAndGitConfig(mockedUtils, mockedFactory, "flyweightFolder");
+    }
+
+    private void setupMockedRequestAndGitConfig(MockedStatic<JsonUtils> mockedUtils, MockedStatic<HelperFactory> mockedFactory, String flyWeightFolder) {
         final String responseBody = "mocked body";
 
         Map<String, Object> requestBody = Map.of(


### PR DESCRIPTION
fixes #282

Otherwise the server will allocate a new flyweight and keep churning every time it polls into a new dir. This doesn't fix all server-side churn of flyweight dirs, e.g you get a new flyweight if you edit the path spec since the fingerprint changes, however we should avoid such churn during automatic flows.

Have left the server to handle and report the "must contain a valid SCM revision" logic as it currently does.

Also will clean up the flyweight if there is an issue with cloning itself as well.